### PR TITLE
Runtime timeout

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -198,6 +198,7 @@ type Config struct {
 	NoFileWrites bool
 	NoFileReads  bool
 
+	// RuntimeLimit is the limit of the amount of time a single program can run
 	RuntimeLimit time.Duration
 }
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/benhoyt/goawk/interp"
 	"github.com/benhoyt/goawk/parser"
@@ -1000,6 +1001,31 @@ func TestSafeMode(t *testing.T) {
 				config.NoExec = true
 				config.NoFileWrites = true
 				config.NoFileReads = true
+			})
+		})
+	}
+}
+func TestTimeout(t *testing.T) {
+	tests := []struct {
+		src  string
+		in   string
+		out  string
+		err  string
+		args []string
+	}{
+		{`BEGIN { print "hi" }`, "", "hi\nhi\n", "", nil},
+		{`BEGIN { while(i<1){} }`, "", "", "Runtime exceeded timeout 5ms", nil},
+		{`BEGIN { while(i<1){i++} }`, "", "", "", nil},
+	}
+	for _, test := range tests {
+		testName := test.src
+		if len(testName) > 70 {
+			testName = testName[:70]
+		}
+		t.Run(testName, func(t *testing.T) {
+			testGoAWK(t, test.src, test.in, test.out, test.err, nil, func(config *interp.Config) {
+				config.Args = test.args
+				config.Timeout = 5 * time.Millisecond
 			})
 		})
 	}


### PR DESCRIPTION
## Goal

For embedded use cases it is really helpful to have a limit on the amount of time a script takes to run. As there has already been sandbox configuration for file read/write/execute which would be critical for embedding in an app. If all IO is disabled then this feature should provide some amount of sandboxing of runtime.

## Implementation
This adds a runtime duration to running a program. It uses `time.Since` on any call to `interp.eval`. 

## IO Issue
On question is how to set timeout for IO operations. Currently this is not supported. Not sure there is a really good option for this. Possibly exposing the a function that can check for runtime limitations might help with embedded use cases.
